### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.3.4] - 2023-07-18
 
 ### Changed

--- a/helm/squid-proxy/values.yaml
+++ b/helm/squid-proxy/values.yaml
@@ -6,7 +6,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/squid
   tag: 5.2-22.04_beta-giantswarm_gs1
   pullPolicy: IfNotPresent
@@ -38,9 +38,9 @@ securityContext:
     type: RuntimeDefault
   capabilities:
     drop:
-    - ALL
+      - ALL
     add:
-    - NET_BIND_SERVICE
+      - NET_BIND_SERVICE
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
