### PR TITLE
Update service.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `external-dns.alpha.kubernetes.io/hostname` annotation.
+
 ## [0.5.3] - 2024-02-09
 
 ### Added

--- a/helm/squid-proxy/templates/service.yaml
+++ b/helm/squid-proxy/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
   {{- if .Values.baseDomain }}
-    external-dns.alpha.kubernetes.io/hostname: "proxy.{{ .Values.baseDomain }}"
+    external-dns.alpha.kubernetes.io/hostname: "proxy.{{ .Values.clusterID }}.{{ .Values.baseDomain }}"
     giantswarm.io/external-dns: managed
   {{- end }}
   {{- if or (eq .Values.provider "aws") (eq .Values.provider "capa") }}


### PR DESCRIPTION
### What this PR does / why we need it

Currently the annotation has this value: 

`external-dns.alpha.kubernetes.io/hostname: proxy.gaws.gigantic.io`

But the hostname we are using everywhere is:

`proxy.goatproxy.gaws.gigantic.io`

because without `goatproxy` the DNS zone is not managed by external DNS running in `goatproxy` cluster and it would be pointless anyway

### Checklist

- [x] Update changelog in CHANGELOG.md.
