### PR TITLE
allow .slack.com domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow `.slack.com` in order to allow Alertmanager to use new Slack API (at `https://slack.com/api`) and also keep backward compatibility with the old Slack Webhooks API (at `https://hooks.slack.com`).
+
 ## [0.5.5] - 2024-02-14
 
 ### Added

--- a/helm/squid-proxy/templates/configmap.yaml
+++ b/helm/squid-proxy/templates/configmap.yaml
@@ -35,7 +35,7 @@ data:
     graph.microsoft.com
     gsoci.azurecr.io
     gsociprivate.azurecr.io
-    hooks.slack.com
+    .slack.com
     k8s.gcr.io
     .keybase.io
     login.microsoftonline.com


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30612

On installations behind a proxy, the Slack API (at https:/slack.com/api) is currently not reachable. This is required in order for Alertmanager to be able to post alerts on Slack using the new https://slack.com/api/chat.postMessage API
This PR add `slack.com` in the list of allowed domains and also keeps compatibility with `hooks.slack.com` currently used by most installations (this can later be removed when all Alertmanager are using the new Slack API).