### PR TITLE
Remove auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove auth0 (`giantswarm.eu.auth0.com`).
+
 ## [0.6.1] - 2024-10-03
 
 ### Added

--- a/helm/squid-proxy/templates/configmap.yaml
+++ b/helm/squid-proxy/templates/configmap.yaml
@@ -25,7 +25,6 @@ data:
     .flatcar-linux.org
     ghcr.io
     giantswarm.azurecr.io
-    giantswarm.eu.auth0.com
     giantswarmpublic.azurecr.io
     .gigantic.io
     .github.com


### PR DESCRIPTION
We [no longer use auth0](https://github.com/giantswarm/giantswarm/issues/23694)

### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.
