### PR TITLE
Add PagerDuty API to allowlist domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `api.eu.pagerduty.com` to allowed domains.
+
 ### Removed
 
 - Remove auth0 (`giantswarm.eu.auth0.com`).

--- a/helm/squid-proxy/templates/configmap.yaml
+++ b/helm/squid-proxy/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
   allowlist-domains: |
     .alpinelinux.org
     .amazonaws.com
+    api.eu.pagerduty.com
     .api.letsencrypt.org
     api.opsgenie.com
     azure.microsoft.com


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34198

Add PagerDuty API to allowlist domains


### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.