### PR TITLE
chore: remove decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed decommissioned `giantswarmpublic.azurecr.io` registry from the egress allowlist (charts moved to `gsoci.azurecr.io`).
 - Removed `PodSecurityPolicy`.
 - Removed `podSecurityPolicy.enabled` helm value.
 - Removed `global.podSecurityStandards.enforced` helm value.

--- a/helm/squid-proxy/templates/configmap.yaml
+++ b/helm/squid-proxy/templates/configmap.yaml
@@ -27,7 +27,6 @@ data:
     .flatcar-linux.org
     ghcr.io
     giantswarm.azurecr.io
-    giantswarmpublic.azurecr.io
     .gigantic.io
     .github.com
     .github.io


### PR DESCRIPTION
### What this PR does / why we need it

`giantswarmpublic.azurecr.io` (which hosted Giant Swarm Helm chart catalogs) has been decommissioned; the charts moved to `gsoci.azurecr.io`. This squid proxy egress allowlist no longer needs the old domain, so its entry is removed.

`gsoci.azurecr.io` is already present in the allowlist, so no new entry is required.

### Checklist

- [x] Update changelog in CHANGELOG.md.